### PR TITLE
Improve extensiblility of Event Pages

### DIFF
--- a/src/model/EventPage.php
+++ b/src/model/EventPage.php
@@ -68,7 +68,6 @@ class EventPage extends Page
 
     public function getCMSFields()
     {
-
         $this->beforeUpdateCMSFields(function ($fields) {
 
             $summary = HtmlEditorField::create('Summary', false);

--- a/src/model/EventPage.php
+++ b/src/model/EventPage.php
@@ -68,33 +68,37 @@ class EventPage extends Page
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
-        $summary = HtmlEditorField::create('Summary', false);
-        $summary->setRows(5);
-        $summary->setDescription(_t(
-            __CLASS__ . '.SummaryDescription',
-            'If no summary is specified the first 30 words will be used.'
-        ));
 
-        $summaryHolder = ToggleCompositeField::create(
-            'CustomSummary',
-            _t(__CLASS__ . '.CustomSummary', 'Add A Custom Summary'), [
-                $summary
-            ]
-        )->setHeadingLevel(4)->addExtraClass('custom-summary');
+        $this->beforeUpdateCMSFields(function ($fields) {
 
-        $uploadField = UploadField::create('FeaturedImage', _t(__CLASS__ . '.FeaturedImage', 'Featured Image'));
-        $uploadField->getValidator()->setAllowedExtensions(['jpg', 'jpeg', 'png', 'gif']);
+            $summary = HtmlEditorField::create('Summary', false);
+            $summary->setRows(5);
+            $summary->setDescription(_t(
+                __CLASS__ . '.SummaryDescription',
+                'If no summary is specified the first 30 words will be used.'
+            ));
 
-        $fields->insertBefore('Metadata', $uploadField );
-        $fields->insertBefore('Metadata', $summaryHolder );
+            $summaryHolder = ToggleCompositeField::create(
+                'CustomSummary',
+                _t(__CLASS__ . '.CustomSummary', 'Add A Custom Summary'), [
+                    $summary
+                ]
+            )->setHeadingLevel(4)->addExtraClass('custom-summary');
 
-        $fields->addFieldsToTab('Root.Date', [
-            GridField::create('DateTimes', 'DateTimes', $this->DateTimes()->sort('StartDate DESC'), EventDateTimeGridField::create())
-                ->setDescription(_t(__CLASS__ . '.DateTimesDescription', 'You can add multiple dates for a event.'))
-        ]);
+            $uploadField = UploadField::create('FeaturedImage', _t(__CLASS__ . '.FeaturedImage', 'Featured Image'));
+            $uploadField->getValidator()->setAllowedExtensions(['jpg', 'jpeg', 'png', 'gif']);
 
-        return $fields;
+            $fields->insertBefore('Metadata', $uploadField );
+            $fields->insertBefore('Metadata', $summaryHolder );
+
+            $fields->addFieldsToTab('Root.Date', [
+                GridField::create('DateTimes', 'DateTimes', $this->DateTimes()->sort('StartDate DESC'), EventDateTimeGridField::create())
+                    ->setDescription(_t(__CLASS__ . '.DateTimesDescription', 'You can add multiple dates for a event.'))
+            ]);
+
+        });
+
+        return parent::getCMSFields();
     }
 
     /**


### PR DESCRIPTION
At the moment when extended the Event Page, updateCMSFields is called before Event Page scaffolds it’s own fields.

The fields should be added inside a beforeUpdateCMSFields method. This allows for better customisation, e.g. removal of fields, or placing before exisiting fields.